### PR TITLE
Fix "Avoid mutable default arguments" issue

### DIFF
--- a/objutils/dwarf/die.py
+++ b/objutils/dwarf/die.py
@@ -53,7 +53,11 @@ class Attribute(object):
 class DebuggingInformationEntry(object):
     __slots__ = ['_tag', '_attributes', '_parent', '_siblings', '_children']
 
-    def __init__(self, tag, attributes, parent = None, siblings = [], children = []):
+    def __init__(self, tag, attributes, parent = None, siblings = None, children = None):
+      if siblings is None:
+        siblings = []
+      if children is None:
+        children = []
       self._tag = tag
       self._attributes = attributes
       self._parent = parent

--- a/objutils/image.py
+++ b/objutils/image.py
@@ -43,7 +43,9 @@ AS_64   = 3
 
 class Image(object):
 
-    def __init__(self, sections = None, meta = {}, valid = False):
+    def __init__(self, sections = None, meta = None, valid = False):
+        if meta is None:
+            meta = {}
         self.sections = sections if sections else []
         _validateSections(self.sections)
         self.meta = meta

--- a/objutils/srec.py
+++ b/objutils/srec.py
@@ -164,7 +164,9 @@ class Writer(hexfile.Writer):
         self.offset = self.recordType + 2
 
 
-    def srecord(self, recordType, length, address, data = []):
+    def srecord(self, recordType, length, address, data = None):
+        if data is None:
+            data = []
         length += self.offset
         addressBytes = utils.intToArray(address)
         checksum = self.checksum(makeList(addressBytes, length, data))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Avoid mutable default arguments](https://www.quantifiedcode.com/app/issue_class/3P0qV6OB)
Issue details: [https://www.quantifiedcode.com/app/project/gh:christoph2:objutils?groups=code_patterns/%3A3P0qV6OB](https://www.quantifiedcode.com/app/project/gh:christoph2:objutils?groups=code_patterns/%3A3P0qV6OB)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)