### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/objutils/fpc.py
+++ b/objutils/fpc.py
@@ -42,7 +42,7 @@ EOF         = 4
 PREFIX      = '$'
 
 MAPPING = dict(enumerate(chr(n) for n in range(37, 123) if not n in (42, )))
-REV_MAPPING = dict([(ord(value), key) for key, value in MAPPING.items()])
+REV_MAPPING = {ord(value): key for key, value in MAPPING.items()}
 NULLS = re.compile(r'\0*\s*!M\s*(.*)', re.DOTALL | re.M)
 VALID_CHARS = re.compile("^\{0}[{1}]+$".format(PREFIX, re.escape(''.join(MAPPING.values()))))
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:christoph2:objutils?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:christoph2:objutils?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)