### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/objutils/ieee695.py
+++ b/objutils/ieee695.py
@@ -373,7 +373,7 @@ class Reader(object):
         self.currentSectionIndex = index
 
     def checkSectionIndex(self, index):
-        if  self.currentSectionIndex == None:
+        if  self.currentSectionIndex is None:
             print("No current Section Index.")
         elif self.currentSectionIndex != index:
             print
@@ -886,7 +886,7 @@ class Reader(object):
         values = []
         while True:
             value = self.checkOptional(self.fpos)
-            if value == None:
+            if value is None:
                 break
             else:
                 values.append(value)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:christoph2:objutils?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:christoph2:objutils?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)