### PR TITLE
Fix "Consider an iterator instead of materializing the list" issue

### DIFF
--- a/objutils/image.py
+++ b/objutils/image.py
@@ -67,7 +67,7 @@ class Image(object):
 
     def __eq__(self, other):
         if len(self.sections) == len(other.sections):
-            return all([operator.eq(l, r) for l, r in zip(self.sections, other.sections)])
+            return all( operator.eq(l, r) for l, r in zip(self.sections, other.sections))
         else:
             return False
 
@@ -125,7 +125,7 @@ def _validateSections(sections):
     if not '__iter__' in dir(sections):
         raise TypeError("Sections must be iteratable.")
     for section in sections:
-        if not all([hasattr(section, attr) for attr in ATTRIBUTES]):
+        if not all( hasattr(section, attr) for attr in ATTRIBUTES):
             raise TypeError("Section '{0}' doesn't fulfills required protocol (missing attributes).")
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider an iterator instead of materializing the list](https://www.quantifiedcode.com/app/issue_class/53lnAzfW)
Issue details: [https://www.quantifiedcode.com/app/project/gh:christoph2:objutils?groups=code_patterns/%3A53lnAzfW](https://www.quantifiedcode.com/app/project/gh:christoph2:objutils?groups=code_patterns/%3A53lnAzfW)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)