### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/objutils/dwarf/constants.py
+++ b/objutils/dwarf/constants.py
@@ -36,7 +36,7 @@ class Base(object):
         return self._value
 
     def __str__(self):
-        return "< %s >" % (self.MAP.get(self._value, self._value))
+        return "< {0!s} >".format((self.MAP.get(self._value, self._value)))
 
     __repr__ = __str__
 

--- a/objutils/dwarf/die.py
+++ b/objutils/dwarf/die.py
@@ -44,7 +44,7 @@ class Attribute(object):
     return self._value
 
   def __repr__(self):
-    return "Attribute(%s = %s)" % (self.name, self.value)
+    return "Attribute({0!s} = {1!s})".format(self.name, self.value)
 
   name = property(_getName)
   value = property(_getValue)

--- a/objutils/dwarf/expressions.py
+++ b/objutils/dwarf/expressions.py
@@ -67,9 +67,9 @@ class LiteralEncoding(object):
 
     def _setValue(self, value):
         if value < self._minimum:
-            raise ValueError("Value must be at least '%u'" % self._minimum)
+            raise ValueError("Value must be at least '{0:d}'".format(self._minimum))
         elif value > self._maximum:
-            raise ValueError("Value must be at most '%u'" % self._maximum)
+            raise ValueError("Value must be at most '{0:d}'".format(self._maximum))
         self._value = value
 
     def _getValue(self):

--- a/objutils/dwarf/sectionreader.py
+++ b/objutils/dwarf/sectionreader.py
@@ -164,7 +164,7 @@ class DebugSectionReader(object):
             attrSpecs = []
             if dr.pos == 0x69:
                 pass
-            print("   %u      %s    [%s]" % (code, tag, "has children" if children == constants.DW_CHILDREN_yes else "no children"))
+            print("   {0:d}      {1!s}    [{2!s}]".format(code, tag, "has children" if children == constants.DW_CHILDREN_yes else "no children"))
             while True:
                 attrValue = dr.uleb()
                 attr = constants.AttributeEncoding(attrValue)
@@ -174,9 +174,9 @@ class DebugSectionReader(object):
                     print("    DW_AT value: 0     DW_FORM value: 0")
                     break
                 if attr.value in attr.MAP:
-                    print("    %s %s" % (attr.MAP[attr.value], form.MAP[form.value]))
+                    print("    {0!s} {1!s}".format(attr.MAP[attr.value], form.MAP[form.value]))
                 else:
-                    print("    Unknown AT value: %x %s" % (attr.value, form.MAP[form.value]))
+                    print("    Unknown AT value: {0:x} {1!s}".format(attr.value, form.MAP[form.value]))
                 attrSpecs.append((attr, form))
             abbrevEntries[code] = AbbreviationEntry(tag, "DW_CHILDREN_yes" if children == constants.DW_CHILDREN_yes else "DW_CHILDREN_no", attrSpecs)
             #print startPos, abbrevEntries[code]
@@ -225,9 +225,9 @@ class DebugSectionReader(object):
                 try:
                     entry = abbrevs[number]
                 except KeyError as e:   # TODO: genau analysieren!!!
-                    print("ENTRY NOT FOUND: %u [%s]" % (number, e))
+                    print("ENTRY NOT FOUND: {0:d} [{1!s}]".format(number, e))
                     continue
-                print("<%x><%x>: Abbrev Number: %u (%s)" % (sectionHeaderStart, entryOffset, number, entry.tag,))
+                print("<{0:x}><{1:x}>: Abbrev Number: {2:d} ({3!s})".format(sectionHeaderStart, entryOffset, number, entry.tag))
                 for attr in entry.attrs:
                     offset = dr.pos
                     attribute, form = attr
@@ -237,7 +237,7 @@ class DebugSectionReader(object):
                         constants.DW_AT_data_member_location):
                         dis = Dissector(attrValue, targetAddrSize)
                         attrValue = dis.run()
-                    print("   <%x>   %18s    : %s" % (offset, attribute, attrValue))
+                    print("   <{0:x}>   {1:18!s}    : {2!s}".format(offset, attribute, attrValue))
         dr.reset()
 
     def processPubNames(self):  # TODO: NameLookupTable
@@ -249,10 +249,10 @@ class DebugSectionReader(object):
             dwarfVersion = dr.u16()
             debugInfoOffs = dr.u32()
             debugInfoLen = dr.u32()
-            print("  Length:                              %u" % (length,  ))
-            print("  Version:                             %u" % (dwarfVersion, ))
-            print("  Offset into .debug_info section:     0x%x" % (debugInfoOffs, ))
-            print("  Size of area in .debug_info section: %u" % (debugInfoLen, ))
+            print("  Length:                              {0:d}".format(length  ))
+            print("  Version:                             {0:d}".format(dwarfVersion ))
+            print("  Offset into .debug_info section:     0x{0:x}".format(debugInfoOffs ))
+            print("  Size of area in .debug_info section: {0:d}".format(debugInfoLen ))
             print()
             print("    Offset      Name")
             while dr.pos < stopPosition:
@@ -261,7 +261,7 @@ class DebugSectionReader(object):
                 if not entryOffset:
                     break
                 entryName = dr.asciiz()
-                print("    %12s %s" % (hex(entryOffset), entryName))
+                print("    {0:12!s} {1!s}".format(hex(entryOffset), entryName))
 
     def scanDebugInfoHeaders(self):
         dr = self.getReader('.debug_info')
@@ -317,26 +317,26 @@ class DebugSectionReader(object):
                     # The last entry is followed by a single null byte.
                     break
 
-            print("  Offset:                      %x" % (sectionOffset, ))           # BYTE-ORDER??!!
-            print("  Length:                      %u" % (length, ))
-            print("  DWARF Version:               %u" % (dwarfVersion))
-            print("  Prologue Length:             %u" % (headerLength, ))            # BYTE-ORDER??!!
-            print("  Minimum Instruction Length:  %u" % (minimumInstructionLength, ))
+            print("  Offset:                      {0:x}".format(sectionOffset ))           # BYTE-ORDER??!!
+            print("  Length:                      {0:d}".format(length ))
+            print("  DWARF Version:               {0:d}".format((dwarfVersion)))
+            print("  Prologue Length:             {0:d}".format(headerLength ))            # BYTE-ORDER??!!
+            print("  Minimum Instruction Length:  {0:d}".format(minimumInstructionLength ))
             #print("  Maximum Operations per Instruction: %u" % (maximumOperationsPerInstruction, ))
-            print("  Initial value of 'is_stmt':  %u" % (defaultIsStmt, ))
-            print("  Line Base:                   %i" % (lineBase, ))
-            print("  Line Range:                  %u" % (lineRange))
-            print("  Opcode Base:                 %u" % (opcodeBase))
+            print("  Initial value of 'is_stmt':  {0:d}".format(defaultIsStmt ))
+            print("  Line Base:                   {0:d}".format(lineBase ))
+            print("  Line Range:                  {0:d}".format((lineRange)))
+            print("  Opcode Base:                 {0:d}".format((opcodeBase)))
 
             print("\n  Opcodes:")
             for idx, args in enumerate(standardOpcodeLengths, 1):
-                print("   Opcode %u has %u args" % (idx, args))
+                print("   Opcode {0:d} has {1:d} args".format(idx, args))
 
             if includeDirectories:
                 #print "What now?"
                  print(" The Directory Table (offset 0x18):") # Cheeck: Offset!??
                  for idx, directory in enumerate(includeDirectories, 1):
-                     print("  %u     %s" % (idx, directory))
+                     print("  {0:d}     {1!s}".format(idx, directory))
             else:
                 print(" The Directory Table is empty.")
 
@@ -352,7 +352,7 @@ class DebugSectionReader(object):
                     timeOfLastModification = dr.uleb()
                     fileLength = dr.uleb()
                     fileNames.append(filename)  # TODO: namedtuple.
-                    print("%u %u %u %u %s" % (idx, directoryIndex, timeOfLastModification, fileLength, filename))
+                    print("{0:d} {1:d} {2:d} {3:d} {4!s}".format(idx, directoryIndex, timeOfLastModification, fileLength, filename))
                 else:
                     break
 
@@ -365,7 +365,7 @@ class DebugSectionReader(object):
             line = 1
             while True:
                 regs = LNSregisters(defaultIsStmt, dr.pos)
-                print("[0x%08x]  " % dr.pos, )
+                print("[0x{0:08x}]  ".format(dr.pos), )
                 opcode = dr.u8()
                 if opcode >= opcodeBase:
                     # Special opcodes.
@@ -384,7 +384,7 @@ class DebugSectionReader(object):
                     regs.prologue_end = False
                     regs.epilogue_begin = False
                     regs.discriminator = 0
-                    print("Special opcode %u: advance Address by %u to 0x%x and Line by %u to %u" % (adjustedOpcode, addrIncr, address, lineIncr, line))
+                    print("Special opcode {0:d}: advance Address by {1:d} to 0x{2:x} and Line by {3:d} to {4:d}".format(adjustedOpcode, addrIncr, address, lineIncr, line))
 
                 else:
                     if opcode == DW_LNS_extended_op:
@@ -398,7 +398,7 @@ class DebugSectionReader(object):
                             print("Extended opcode 1: End of Sequence")
                         elif extOp == constants.DW_LNE_set_address:
                             address = dr.addr()
-                            print("Extended opcode 2: set Address to 0x%x" % address)
+                            print("Extended opcode 2: set Address to 0x{0:x}".format(address))
                         elif extOp == constants.DW_LNE_define_file:
                             print("Extended opcode 3: define new File Table entry")
                             fileName = dr.asciiz()
@@ -407,11 +407,11 @@ class DebugSectionReader(object):
                             fileLength = dr.uleb()
                             # TODO: Append to filename-Table!!!
                             print("Entry Dir     Time    Size    Name")
-                            print(" 1    %u       %u       %u       %s" % (directoryIndex, timeOfLastModification, fileLength, fileName))
+                            print(" 1    {0:d}       {1:d}       {2:d}       {3!s}".format(directoryIndex, timeOfLastModification, fileLength, fileName))
                         elif extOp == constants.DW_LNE_set_discriminator:
                             raise Exception("FIX ME!!!")
                         else:
-                            raise AttributeError("Unexpected extended opcode: '%u'" % opcode)
+                            raise AttributeError("Unexpected extended opcode: '{0:d}'".format(opcode))
                     else:
                         # Standard opcodes.
                         if opcode == constants.DW_LNS_copy:
@@ -420,17 +420,17 @@ class DebugSectionReader(object):
                         elif opcode == constants.DW_LNS_advance_pc:
                             addressIncr = dr.uleb() * minimumInstructionLength
                             address += addressIncr
-                            print("Advance PC by %u to 0x%x" % (addressIncr, address))
+                            print("Advance PC by {0:d} to 0x{1:x}".format(addressIncr, address))
                         elif opcode == constants.DW_LNS_advance_line:
                             lineIncr = dr.uleb()
                             line += lineIncr
-                            print("Advance Line by %u to %u" % (lineIncr, line, ))
+                            print("Advance Line by {0:d} to {1:d}".format(lineIncr, line ))
                         elif opcode == constants.DW_LNS_set_file:
                             regs.fileNumber = dr.uleb()
-                            print("Set File Name to entry %u in the File Name Table" % (regs.fileNumber))
+                            print("Set File Name to entry {0:d} in the File Name Table".format((regs.fileNumber)))
                         elif opcode == constants.DW_LNS_set_column:
                             regs.column = dr.uleb()
-                            print("Set column to %u" % regs.column)
+                            print("Set column to {0:d}".format(regs.column))
                         elif opcode == constants.DW_LNS_negate_stmt:
                             regs.is_stmt = not regs.is_stmt # Check!!!
                         elif opcode == constants.DW_LNS_set_basic_block:
@@ -439,11 +439,11 @@ class DebugSectionReader(object):
                         elif opcode == constants.DW_LNS_const_add_pc:
                             offset = ((255 - opcodeBase) / lineRange) * minimumInstructionLength
                             address += offset
-                            print("Advance PC by constant %u to 0x%x" % (offset, address))
+                            print("Advance PC by constant {0:d} to 0x{1:x}".format(offset, address))
                         elif opcode == constants.DW_LNS_fixed_advance_pc:
                             addrInc = dr.u16()
                             address += addrInc
-                            print("Advance PC by fixed size amount %u to 0x%x" % (addrInc, address))
+                            print("Advance PC by fixed size amount {0:d} to 0x{1:x}".format(addrInc, address))
                         elif opcode == constants.DW_LNS_set_prologue_end:
                             print("Set prologue_end to true")
                             regs.prologue_end = True
@@ -452,7 +452,7 @@ class DebugSectionReader(object):
                         elif opcode == constants.DW_LNS_set_isa:
                             pass
                         else:
-                            raise AttributeError("Unexpected standard opcode: '%u'" % opcode)
+                            raise AttributeError("Unexpected standard opcode: '{0:d}'".format(opcode))
                 regs.line = line
                 regs.address = address
                 lineNumberProgram.append(regs)

--- a/objutils/emon52.py
+++ b/objutils/emon52.py
@@ -73,5 +73,5 @@ class Writer(hexfile.Writer):
 
     def composeRow(self, address, length, row):
         checksum = sum(row) % 65536
-        return "%02X %04X:%s %04X" % (length, address, Writer.hexBytes(row, spaced = True), checksum)
+        return "{0:02X} {1:04X}:{2!s} {3:04X}".format(length, address, Writer.hexBytes(row, spaced = True), checksum)
 

--- a/objutils/etek.py
+++ b/objutils/etek.py
@@ -76,6 +76,6 @@ class Writer(hexfile.Writer):
     def composeRow(self, address, length, row):
         checksum = checksums.nibbleSum(utils.makeList(utils.intToArray(address), 6, ((length + 5) * 2), row))
 
-        line = "%%%02X6%02X%04X%s" % ((length + 5) * 2, checksum, address, Writer.hexBytes(row), )
+        line = "%{0:02X}6{1:02X}{2:04X}{3!s}".format((length + 5) * 2, checksum, address, Writer.hexBytes(row) )
         return line
 

--- a/objutils/fpc.py
+++ b/objutils/fpc.py
@@ -74,7 +74,7 @@ class Reader(hexfile.Reader):
             values = []
             for quintuple in self.splitQuintuples(line):
                 value = self.convertQuintuple(quintuple)
-                values.append("%08X" % value)
+                values.append("{0:08X}".format(value))
             outLines.append(''.join(values))
         return '\n'.join(outLines)
 

--- a/objutils/hexdump.py
+++ b/objutils/hexdump.py
@@ -41,7 +41,7 @@ class Dumper(object):
         self._fp = fp
         self._rolloverMask = 2 ** numAddressBits
         self._nibbles = numAddressBits >> 2
-        self._addressMask = "%%0%ux " % self._nibbles
+        self._addressMask = "%0{0:d}x ".format(self._nibbles)
         self.previousRow = bytes()  # bytearray()
         self.elided = False
 

--- a/objutils/hexfile.py
+++ b/objutils/hexfile.py
@@ -126,7 +126,7 @@ class FormatParser(object):
         length = len(group)
         if groupNumber is None:    # Handle invariants (i.e. fixed chars).
             if group[0] == ' ':
-                expr = '\s{%s}' % (length, )
+                expr = '\s{{{0!s}}}'.format(length )
             else:
                 expr = group[0] * length
         else:
@@ -136,7 +136,7 @@ class FormatParser(object):
             elif groupNumber == DATA:
                 "(?P<chunk>[0-9a-zA-Z]*)"
                 if self.dataSep is not None:
-                    expr = "(?P<chunk>[0-9a-zA-Z%s]*)" % (self.dataSep, )
+                    expr = "(?P<chunk>[0-9a-zA-Z{0!s}]*)".format(self.dataSep )
                 else:
                     pass
             elif groupNumber == UNPARSED:
@@ -240,7 +240,7 @@ class Reader(BaseType):
                             metaData[formatType].append(MetaRecord(formatType, address, chunk))
                     break
             if not matched:
-                self.warn("Ignoring garbage line #%u" % lineNumber)
+                self.warn("Ignoring garbage line #{0:d}".format(lineNumber))
         if sections:
             return Image(joinSections(sections), metaData, self.valid)
         else:
@@ -360,7 +360,7 @@ class Writer(BaseType):
             try:
                 params[k] = getattr(self, k)
             except AttributeError:
-                raise AttributeError("Invalid keyword argument '%s'." % k)
+                raise AttributeError("Invalid keyword argument '{0!s}'.".format(k))
             else:
                 setattr(self, k, v)
         return params
@@ -382,7 +382,7 @@ class Writer(BaseType):
     @staticmethod
     def hexBytes(row, spaced = False):
         spacer = ' ' if spaced else ''
-        return spacer.join(["%02X" % x for x in row])
+        return spacer.join(["{0:02X}".format(x) for x in row])
 
 
 class ASCIIHexReader(Reader):

--- a/objutils/ieee695.py
+++ b/objutils/ieee695.py
@@ -366,7 +366,7 @@ class Reader(object):
             elif cc == ME:
                 self.onME()
             else:
-                raise NotImplementedError("0x%02X" % cc)
+                raise NotImplementedError("0x{0:02X}".format(cc))
 
 
     def setCurrentSectionIndex(self, index):
@@ -423,7 +423,7 @@ class Reader(object):
             # length: [0..65535]
             length = self.readWord(offset + 1)
         else:
-            raise TypeError("Invalid typecode [%02x]." % typecode)
+            raise TypeError("Invalid typecode [{0:02x}].".format(typecode))
         result = self.inFile.read(length)
         self.fpos = self.inFile.tell()
         return result
@@ -467,7 +467,7 @@ class Reader(object):
         self.info.processor = self.readString(self.fpos)
         self.info.module = self.readString(self.fpos)
 
-        self.logger.debug("PROCESSOR: '%s' MODULE: '%s'." % (self.info.processor, self.info.module))
+        self.logger.debug("PROCESSOR: '{0!s}' MODULE: '{1!s}'.".format(self.info.processor, self.info.module))
 
     def onAD(self):
         "$EC}{n1}{n2}[a]"
@@ -490,7 +490,7 @@ class Reader(object):
             sectionIndex = self.readNumber(self.fpos)
             self.checkSectionIndex(sectionIndex)
             self.sections[sectionIndex].sectionSize = self.readNumber(self.fpos)
-            self.logger.debug("Section-Size: 0x%04x" % self.sections[sectionIndex].sectionSize)
+            self.logger.debug("Section-Size: 0x{0:04x}".format(self.sections[sectionIndex].sectionSize))
         elif discr == ASA:
             sectionIndex = self.readNumber(self.fpos)
             self.checkSectionIndex(sectionIndex)
@@ -507,12 +507,12 @@ class Reader(object):
             sectionIndex = self.readNumber(self.fpos)
             self.checkSectionIndex(sectionIndex)
             self.sections[sectionIndex].mauSize = self.readNumber(self.fpos)
-            self.logger.debug("MAU-Size: 0x%04x" % self.sections[sectionIndex].mauSize)
+            self.logger.debug("MAU-Size: 0x{0:04x}".format(self.sections[sectionIndex].mauSize))
         elif discr == ASL:
             sectionIndex = self.readNumber(self.fpos)
             self.checkSectionIndex(sectionIndex)
             self.sections[sectionIndex].sectionBaseAddr = self.readNumber(self.fpos)
-            self.logger.debug("Section-BaseAddr: 0x%04x" % self.sections[sectionIndex].sectionBaseAddr)
+            self.logger.debug("Section-BaseAddr: 0x{0:04x}".format(self.sections[sectionIndex].sectionBaseAddr))
         elif discr == ASM:
             sectionIndex = self.readNumber(self.fpos)
             self.checkSectionIndex(sectionIndex)
@@ -534,7 +534,7 @@ class Reader(object):
             if delim != 0xBE:
                 pass    # todo: FormatError!!!
             executionStartingAddr = self.readNumber(self.fpos)
-            self.logger.debug("STARTING-ADDRESS: 0x%04X" % executionStartingAddr)
+            self.logger.debug("STARTING-ADDRESS: 0x{0:04X}".format(executionStartingAddr))
             delim = self.readByte(self.fpos)
             if delim != 0xBF:
                 pass    # todo: FormatError!!!
@@ -677,7 +677,7 @@ class Reader(object):
             elif attrDef == 65:
                 miscString = self.readString(self.fpos)
             else:
-                raise NotImplementedError("Invalid ATN-Attr: 0x%02x" % attrDef)
+                raise NotImplementedError("Invalid ATN-Attr: 0x{0:02x}".format(attrDef))
                 # todo: FormatError
         else:
             raise NotImplementedError(hex(discr))
@@ -703,7 +703,7 @@ class Reader(object):
             pass
         #todo: 'ZC' / 'ZM'.
         else:
-            raise NotImplementedError("SEG-TYPE: %s" % f)
+            raise NotImplementedError("SEG-TYPE: {0!s}".format(f))
 
         sectionName = self.readString(self.fpos)
         parentSectionIndex = self.checkOptional(self.fpos)
@@ -715,7 +715,7 @@ class Reader(object):
             contextIndex = self.readNumber(self.fpos)
 
         self.sections[sectionIndex] = Section(sectionType, sectionName, parentSectionIndex)
-        self.logger.debug("SECTION [%s:%s]" % (sectionType, sectionName))
+        self.logger.debug("SECTION [{0!s}:{1!s}]".format(sectionType, sectionName))
         # SA, ASA, ASB, ASF, ASL, ASM, ASR, and ASS records must appear after the ST record they refer to.
         '''
         ASP absolute code
@@ -757,7 +757,7 @@ class Reader(object):
         info.nameIndex = nameIndex
         info.symbolName = symbolName
         self.symbols[nameIndex] = info
-        self.logger.debug("SYMBOL: %s" % symbolName) # followed by ASI.
+        self.logger.debug("SYMBOL: {0!s}".format(symbolName)) # followed by ASI.
 
     def onBB(self):
         blockType = self.readByte(self.fpos)
@@ -773,7 +773,7 @@ class Reader(object):
             moduleName = self.readString(self.fpos)
             info.moduleName = moduleName
             info.name = "BB1"
-            self.logger.debug("MODULE-NAME: %s" % moduleName)
+            self.logger.debug("MODULE-NAME: {0!s}".format(moduleName))
         elif blockType == BB2:
             self.blockType.append(2)
             zeroLengthName = self.readString(self.fpos)
@@ -867,7 +867,7 @@ class Reader(object):
         parent = self.diParents[-1]
         parent.add(info)
         self.diParents.append(info)
-        self.logger.debug(" " * len(self.diParents), "BB%u" % blockType)
+        self.logger.debug(" " * len(self.diParents), "BB{0:d}".format(blockType))
 
     def onBE(self):
         blockType = self.blockType.pop()
@@ -895,7 +895,7 @@ class Reader(object):
         "{$E5}{n1}"
         sectionIndex = self.readNumber(self.fpos)
         sec = self.sections[sectionIndex]
-        self.logger.debug("Data for section: '%s'. %u bytes of data to follow." % (
+        self.logger.debug("Data for section: '{0!s}'. {1:d} bytes of data to follow.".format(
             sec.sectionName, sec.sectionSize
         ))
 
@@ -903,7 +903,7 @@ class Reader(object):
         "{$ED}{n1}{...}"
         numberOfMAUs = self.readNumber(self.fpos)
         data = self.inFile.read((numberOfMAUs * self.info.numberOfBits) / 8)
-        self.logger.debug("reading %u bytes" % len(data))
+        self.logger.debug("reading {0:d} bytes".format(len(data)))
 
 
         # SB ASP LD
@@ -916,7 +916,7 @@ class Reader(object):
     def onME(self):
         "Module End Record Type"
         self.finished = True
-        self.logger.debug("%u Data-Bytes." % self._nb)
+        self.logger.debug("{0:d} Data-Bytes.".format(self._nb))
 
 
 ## $C0-$DA Variable letters (null, A-Z).

--- a/objutils/ihex.py
+++ b/objutils/ihex.py
@@ -94,7 +94,7 @@ class Reader(hexfile.Reader):
                 line.addPI(('eip', eip))
                 self.debug("START_LINEAR_ADDRESS: {0}".format(hex(eip)))
             else:
-                self.error("Bad Linear Address at line #%u." % line.lineNumber)
+                self.error("Bad Linear Address at line #{0:d}.".format(line.lineNumber))
         elif line.type == EOF:
             pass
         else:
@@ -123,7 +123,7 @@ class Writer(hexfile.Writer):
         ## buildLine()
         line = ""
         for b in data:
-            line += "%02X" % b
+            line += "{0:02X}".format(b)
 
-        self.outFile.write(":%02X%04X%02X%s%02X" % (length, address, type_, line, checksum))
+        self.outFile.write(":{0:02X}{1:04X}{2:02X}{3!s}{4:02X}".format(length, address, type_, line, checksum))
 

--- a/objutils/image.py
+++ b/objutils/image.py
@@ -76,7 +76,7 @@ class Image(object):
 
     def hexdump(self, fp = sys.stdout):
         for idx, section in enumerate(self.sections):
-            print("\nSection #%04d" % (idx, ), file = fp)
+            print("\nSection #{0:04d}".format(idx ), file = fp)
             print("-" * 13, file = fp)
             section.hexdump(fp)
 

--- a/objutils/mostec.py
+++ b/objutils/mostec.py
@@ -60,7 +60,7 @@ class Writer(hexfile.Writer):
 
     def composeRow(self, address, length, row):
         checksum = checksums.lrc(utils.makeList(utils.intToArray(address), length, row), 16, checksums.COMPLEMENT_NONE)
-        line = ";%02X%04X%s%04X" % (length, address, Writer.hexBytes(row), checksum)
+        line = ";{0:02X}{1:04X}{2!s}{3:04X}".format(length, address, Writer.hexBytes(row), checksum)
         return line
 
     def composeFooter(self, meta):

--- a/objutils/rca.py
+++ b/objutils/rca.py
@@ -53,15 +53,15 @@ class Reader(hexfile.Reader):
 
 
 class Writer(hexfile.Writer):
-    SEPARATOR = "%s\x0d\x0a" % ('\x00' * 48)
+    SEPARATOR = "{0!s}\x0d\x0a".format(('\x00' * 48))
     MAX_ADDRESS_BITS = 16
 
     def composeRow(self, address, length, row):
-        return "%04X %s;" % (address, Writer.hexBytes(row))
+        return "{0:04X} {1!s};".format(address, Writer.hexBytes(row))
 
     def composeHeader(self, meta):
-        return "%s!M" % Writer.SEPARATOR
+        return "{0!s}!M".format(Writer.SEPARATOR)
 
     def composeFooter(self, meta):
-        return "%s" % Writer.SEPARATOR
+        return "{0!s}".format(Writer.SEPARATOR)
 

--- a/objutils/srec.py
+++ b/objutils/srec.py
@@ -93,7 +93,7 @@ class Reader(hexfile.Reader):
                 ((line.address & 0xff00) >>8 )+(line.address & 0xff)
             )
         else:
-            raise TypeError("Invalid format type '%s'." % formatType)
+            raise TypeError("Invalid format type '{0!s}'.".format(formatType))
         if hasattr(line, 'chunk'):
             checksum = (~(sum([line.length,checkSumOfAddress]) + sum(line.chunk))) & 0xff
         else:
@@ -160,7 +160,7 @@ class Writer(hexfile.Writer):
                 self.recordType = 2
             elif highestAddress <= 0xffffffff:
                 self.recordType = 3
-        self.addressMask = "%%0%uX" % ((self.recordType + 1) * 2, )
+        self.addressMask = "%0{0:d}X".format((self.recordType + 1) * 2 )
         self.offset = self.recordType + 2
 
 
@@ -168,7 +168,7 @@ class Writer(hexfile.Writer):
         length += self.offset
         addressBytes = utils.intToArray(address)
         checksum = self.checksum(makeList(addressBytes, length, data))
-        mask = "S%%u%%02X%s%%s%%02X" % self.addressMask
+        mask = "S%u%02X{0!s}%s%02X".format(self.addressMask)
         return mask % (recordType, length, address, Writer.hexBytes(data), checksum)
 
     def composeRow(self, address, length, row):

--- a/objutils/tek.py
+++ b/objutils/tek.py
@@ -67,7 +67,7 @@ class Writer(hexfile.Writer):
         addressChecksum = checksums.nibbleSum(utils.makeList(utils.intToArray(address), length))
 
         dataChecksum = checksums.nibbleSum(row)
-        line = "/%04X%02X%02X%s%02X" % (address, length, addressChecksum, Writer.hexBytes(row), dataChecksum)
+        line = "/{0:04X}{1:02X}{2:02X}{3!s}{4:02X}".format(address, length, addressChecksum, Writer.hexBytes(row), dataChecksum)
         self.lastAddress = address + length
         return line
 

--- a/objutils/tools/readelf.py
+++ b/objutils/tools/readelf.py
@@ -666,18 +666,18 @@ class ELFReader(object):
     def printFileHeader(self, reader):
         if self.options.fileHeader:
             print("ELF Header:")
-            print("  Magic:   " + ' '.join(["%02x" %(ord(x)) for x in reader.header.magicBytes[:16]]) + " ")
-            print("  Class:                             %s" % (reader.header.elfClassAsString()))
-            print("  Data:                              %s" % reader.header.elfDataEncodingAsString())
-            print("  Version:                           %d %s" % (reader.header.elfVersion, reader.header.getVersionAsString()))
-            print("  OS/ABI:                            %s" % (reader.header.getAbiNameAsString()))
-            print("  ABI Version:                       %d" % (reader.header.elfAbiVersion))
-            print("  Type:                              %s" % reader.header.getElfTypeAsString())
-            print("  Machine:                           %s" % reader.header.elfMachineName)
+            print("  Magic:   " + ' '.join(["{0:02x}".format((ord(x))) for x in reader.header.magicBytes[:16]]) + " ")
+            print("  Class:                             {0!s}".format((reader.header.elfClassAsString())))
+            print("  Data:                              {0!s}".format(reader.header.elfDataEncodingAsString()))
+            print("  Version:                           {0:d} {1!s}".format(reader.header.elfVersion, reader.header.getVersionAsString()))
+            print("  OS/ABI:                            {0!s}".format((reader.header.getAbiNameAsString())))
+            print("  ABI Version:                       {0:d}".format((reader.header.elfAbiVersion)))
+            print("  Type:                              {0!s}".format(reader.header.getElfTypeAsString()))
+            print("  Machine:                           {0!s}".format(reader.header.elfMachineName))
             print("  Version:                           0x%lx" % reader.header.elfVersion)
-            print("  Entry point address:               0x%x" % (reader.header.elfEntryPoint))  #  (bytes into file)
-            print("  Start of program headers:          %d (bytes into file)" % (reader.header.elfProgramHeaderTableOffset))
-            print("  Start of section headers:          %d (bytes into file)" % (reader.header.elfSectionHeaderTableOffset))
+            print("  Entry point address:               0x{0:x}".format((reader.header.elfEntryPoint)))  #  (bytes into file)
+            print("  Start of program headers:          {0:d} (bytes into file)".format((reader.header.elfProgramHeaderTableOffset)))
+            print("  Start of section headers:          {0:d} (bytes into file)".format((reader.header.elfSectionHeaderTableOffset)))
             print("  Flags:                             0x%lx%s" % (reader.header.elfFlags, getMachineFlags(reader.header.elfFlags, reader.header.elfMachine)))
             print("  Size of this header:               %ld (bytes)" % (reader.header.elfEHSize))
             print("  Size of program headers:           %ld (bytes)" % (reader.header.elfPHTEntrySize))
@@ -690,7 +690,7 @@ class ELFReader(object):
                 print(" (%ld)" % reader.section_headers[0].sh_size);
             print("  Section header string table index: %ld" % (reader.header.elfStringTableIndex))
             if reader.sectionHeaders and reader.header.e_shstrndx == defs.SHN_XINDEX:
-                print(" (%u)" % reader.header.section_headers[0].sh_link);
+                print(" ({0:d})".format(reader.header.section_headers[0].sh_link));
             elif reader.header.e_shstrndx != defs.SHN_UNDEF and reader.header.e_shstrndx > reader.header.e_shnum:
                 print(" <corrupt: out of range>")
 
@@ -704,9 +704,9 @@ class ELFReader(object):
                 return
 
         if self.doSegments and not self.doHeader:
-            print("Elf file type is %s" % reader.header.getElfTypeAsString())
-            print("Entry point 0x%x" % reader.header.e_entry)
-            print("There are %d program headers, starting at offset %d" % (reader.header.e_phnum, reader.header.e_phoff))
+            print("Elf file type is {0!s}".format(reader.header.getElfTypeAsString()))
+            print("Entry point 0x{0:x}".format(reader.header.e_entry))
+            print("There are {0:d} program headers, starting at offset {1:d}".format(reader.header.e_phnum, reader.header.e_phoff))
         elif not self.doSegments:
             return
         print
@@ -802,7 +802,7 @@ class ELFReader(object):
                 """
             elif header.phType == defs.PT_INTERP:
                 if self.doSegments:
-                    print("      [Requesting program interpreter: %s]" % (header.image.strip()))
+                    print("      [Requesting program interpreter: {0!s}]".format((header.image.strip())))
 
         if self.doSegments and reader.sectionHeaders:   # and reader.stringTable
             print("\n Section to Segment mapping:")

--- a/objutils/utils.py
+++ b/objutils/utils.py
@@ -181,17 +181,17 @@ class RepresentationMixIn(object):
     def __repr__(self):
         keys = [k for k in self.__dict__ if not (k.startswith('__') and k.endswith('__'))]
         result = []
-        result.append("%s {" % self.__class__.__name__)
+        result.append("{0!s} {{".format(self.__class__.__name__))
         for key in keys:
             value = getattr(self, key)
             if isinstance(value, (int, long)):
-                line = "    %s = 0x%X" % (key, value)
+                line = "    {0!s} = 0x{1:X}".format(key, value)
             elif isinstance(value, (float, types.NoneType)):
-                line = "    %s = %s" % (key, value)
+                line = "    {0!s} = {1!s}".format(key, value)
             elif isinstance(value, array):
-                line = "    %s = %s" % (key, helper.hexDump(value))
+                line = "    {0!s} = {1!s}".format(key, helper.hexDump(value))
             else:
-                line = "    %s = '%s'" % (key, value)
+                line = "    {0!s} = '{1!s}'".format(key, value)
             result.append(line)
         result.append("}")
         return '\n'.join(result)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages
 from glob import glob
 
 def packagez(base):
-    return  ["%s%s%s" % (base, os.path.sep, p) for p in find_packages(base)]
+    return  ["{0!s}{1!s}{2!s}".format(base, os.path.sep, p) for p in find_packages(base)]
 
 from distutils.core import setup,Extension
 from setuptools import find_packages,setup


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:christoph2:objutils?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:christoph2:objutils?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)